### PR TITLE
Switch to SIGKILL string to kill process

### DIFF
--- a/run.js
+++ b/run.js
@@ -25,7 +25,7 @@ module.exports = function run(location, localCall) {
   return {
     kill: function (cb) {
       proc.once('exit', function () { cb() })
-      proc.kill(9)
+      proc.kill('SIGKILL')
     },
     remoteCall: stream.remoteCall,
     proc: proc,


### PR DESCRIPTION
This unbreaks Node 6 tests upstream in ssb-server.

---

I've also enabled Travis CI on this repo so we have tests. :+1: 