### PR TITLE
Fixed bug that broke installing without kwargs

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ module.exports = {
         var pluginName
         if(isString(opts)) {
           pluginName = opts
-          opts = _opts
+          opts = _opts ? _opts : {} // since muxrpcli will set _opts to undefined if there were no kwargs
           opts.module = pluginName
         }
         else {
@@ -195,7 +195,7 @@ module.exports = {
         var pluginName
         if(isString(opts)) {
           pluginName = opts
-          opts = _opts
+          opts = _opts ? _opts : {}
         }
         else {
           pluginName = opts.name


### PR DESCRIPTION
In all available documentation sources, the CLI for ssb-plugins is given as

`sbot plugins.install plugin-name`

However, on Ubuntu 20.04.41 and with muxrpcli 3.1.2, this will throw an error of the form

```
/usr/local/lib/node_modules/ssb-server/node_modules/muxrpcli/index.js:123
      throw err
      ^
TypeError: Cannot set property 'module' of undefined
    at Object.install (/usr/local/lib/node_modules/ssb-server/node_modules/ssb-plugins/index.js:117:23)
    at Object.hooked (/usr/local/lib/node_modules/ssb-server/node_modules/hoox/index.js:10:15)
    at Object.localCall (/usr/local/lib/node_modules/ssb-server/node_modules/muxrpc/local-api.js:31:29)
    at Object.<anonymous> (/usr/local/lib/node_modules/ssb-server/node_modules/muxrpc/local-api.js:37:22)
    at PacketStreamSubstream.stream.read (/usr/local/lib/node_modules/ssb-server/node_modules/muxrpc/stream.js:69:23)
    at PacketStream._onstream (/usr/local/lib/node_modules/ssb-server/node_modules/packet-stream/index.js:228:11)
    at PacketStream.write (/usr/local/lib/node_modules/ssb-server/node_modules/packet-stream/index.js:135:41)
    at /usr/local/lib/node_modules/ssb-server/node_modules/muxrpc/pull-weird.js:56:15
    at /usr/local/lib/node_modules/ssb-server/node_modules/pull-stream/sinks/drain.js:24:37
    at /usr/local/lib/node_modules/ssb-server/node_modules/pull-goodbye/node_modules/pull-stream/throughs/filter.js:17:11
```

This is because install/uninstall commands assume `_opts` is not undefined, while on muxrpcli 3.1.2, _opts will be undefined if no keyword args are passed.

The problem is fixed simply by setting _opts to an empty object if it is undefined.